### PR TITLE
Criar endpoint para listagem de solicitações#7 - Medico

### DIFF
--- a/src/main/java/ufpi/engsoft2/seyfert/controller/SolicitacaoController.java
+++ b/src/main/java/ufpi/engsoft2/seyfert/controller/SolicitacaoController.java
@@ -41,12 +41,21 @@ public class SolicitacaoController {
         return ResponseEntity.created(uri).body(solicitacaoDTO);
     }
 
-    @GetMapping("/{uuidPaciente}")
+    @GetMapping("/paciente/{uuidPaciente}")
     public ResponseEntity<Page<SolicitacaoDTO>> listarSolicitacoesPaciente(@PathVariable UUID uuidPaciente,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataParaAtendimento,
             @RequestParam(required = false) String nomeEspecialidade,
             @PageableDefault(sort = "dataParaAtendimento", direction = Sort.Direction.DESC, page = 0, size = 10) Pageable pageable) {
         return ResponseEntity.ok().body(solicitacaoService.listarSolicitacoesPaciente(uuidPaciente, dataParaAtendimento,
+                nomeEspecialidade, pageable));
+    }
+
+    @GetMapping("/medico/{uuidMedico}")
+    public ResponseEntity<Page<SolicitacaoDTO>> listarSolicitacoesMedico(@PathVariable UUID uuidMedico,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataParaAtendimento,
+            @RequestParam(required = false) String nomeEspecialidade,
+            @PageableDefault(sort = "dataParaAtendimento", direction = Sort.Direction.DESC, page = 0, size = 10) Pageable pageable) {
+        return ResponseEntity.ok().body(solicitacaoService.listarSolicitacoesMedico(uuidMedico, dataParaAtendimento,
                 nomeEspecialidade, pageable));
     }
 }

--- a/src/main/java/ufpi/engsoft2/seyfert/domain/repository/MedicoRepository.java
+++ b/src/main/java/ufpi/engsoft2/seyfert/domain/repository/MedicoRepository.java
@@ -1,0 +1,11 @@
+package ufpi.engsoft2.seyfert.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import ufpi.engsoft2.seyfert.domain.model.Medico;
+
+public interface MedicoRepository extends JpaRepository<Medico, UUID>{
+    Medico findByUuid(UUID uuidMedico);
+}

--- a/src/main/java/ufpi/engsoft2/seyfert/domain/repository/SolicitacaoRepository.java
+++ b/src/main/java/ufpi/engsoft2/seyfert/domain/repository/SolicitacaoRepository.java
@@ -1,6 +1,7 @@
 package ufpi.engsoft2.seyfert.domain.repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -8,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import ufpi.engsoft2.seyfert.domain.model.EspecialidadeMedica;
 import ufpi.engsoft2.seyfert.domain.model.Solicitacao;
 
 @Repository
@@ -16,4 +18,8 @@ public interface SolicitacaoRepository extends JpaRepository<Solicitacao, Long> 
     Page<Solicitacao> findByPacienteUuidAndDataParaAtendimento(UUID uuidPaciente, LocalDate dataParaAtendimento, Pageable pageable);
     Page<Solicitacao> findByPacienteUuidAndEspecialidadeMedicaUuid(UUID uuidPaciente, UUID uuidEspecialidade, Pageable pageable);
     Page<Solicitacao> findByPacienteUuidAndDataParaAtendimentoAndEspecialidadeMedicaUuid(UUID uuidPaciente, LocalDate dataParaAtendimento, UUID uuidEspecialidade, Pageable pageable);
+    Page<Solicitacao> findByEspecialidadeMedicaUuid(UUID uuidEspecialidade, Pageable pageable);
+    Page<Solicitacao> findByEspecialidadeMedicaIn(List<EspecialidadeMedica> especialidades, Pageable pageable);
+    Page<Solicitacao> findByEspecialidadeMedicaInAndDataParaAtendimento(List<EspecialidadeMedica> especialidades, LocalDate dataParaAtendimento, Pageable pageable);
+    Page<Solicitacao> findByEspecialidadeMedicaUuidAndDataParaAtendimento(UUID uuidEspecialidade, LocalDate dataParaAtendimento, Pageable pageable);
 }

--- a/src/main/java/ufpi/engsoft2/seyfert/service/solicitacao/SolicitacaoService.java
+++ b/src/main/java/ufpi/engsoft2/seyfert/service/solicitacao/SolicitacaoService.java
@@ -12,4 +12,5 @@ import ufpi.engsoft2.seyfert.domain.form.SolicitacaoForm;
 public interface SolicitacaoService {
     SolicitacaoDTO cadastrar(SolicitacaoForm solicitacao);
     Page<SolicitacaoDTO> listarSolicitacoesPaciente(UUID uuidPaciente, LocalDate dataParaAtendimento, String nomeEspecialidade, Pageable pageable);
+    Page<SolicitacaoDTO> listarSolicitacoesMedico(UUID uuidMedico, LocalDate dataParaAtendimento, String nomeEspecialidade, Pageable pageable);
 }

--- a/src/main/java/ufpi/engsoft2/seyfert/service/solicitacao/impl/SolicitacaoServiceImpl.java
+++ b/src/main/java/ufpi/engsoft2/seyfert/service/solicitacao/impl/SolicitacaoServiceImpl.java
@@ -1,6 +1,7 @@
 package ufpi.engsoft2.seyfert.service.solicitacao.impl;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,8 +14,11 @@ import lombok.NoArgsConstructor;
 import ufpi.engsoft2.seyfert.domain.dto.SolicitacaoDTO;
 import ufpi.engsoft2.seyfert.domain.enums.SituacaoSolicitacao;
 import ufpi.engsoft2.seyfert.domain.form.SolicitacaoForm;
+import ufpi.engsoft2.seyfert.domain.model.EspecialidadeMedica;
+import ufpi.engsoft2.seyfert.domain.model.Medico;
 import ufpi.engsoft2.seyfert.domain.model.Solicitacao;
 import ufpi.engsoft2.seyfert.domain.repository.EspecialidadeMedicaRepository;
+import ufpi.engsoft2.seyfert.domain.repository.MedicoRepository;
 import ufpi.engsoft2.seyfert.domain.repository.SolicitacaoRepository;
 import ufpi.engsoft2.seyfert.service.solicitacao.SolicitacaoMapper;
 import ufpi.engsoft2.seyfert.service.solicitacao.SolicitacaoService;
@@ -25,6 +29,8 @@ import ufpi.engsoft2.seyfert.shared.exception.EntityNotFoundException;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SolicitacaoServiceImpl implements SolicitacaoService {
+    @Autowired
+    private MedicoRepository medicoRepository;
 
     @Autowired
     private EspecialidadeMedicaRepository especialidadeMedicaRepository;
@@ -52,7 +58,6 @@ public class SolicitacaoServiceImpl implements SolicitacaoService {
         return solicitacaoDTO;
     }
 
-    @Override
     public Page<SolicitacaoDTO> listarSolicitacoesPaciente(UUID uuidPaciente, LocalDate dataParaAtendimento,
             String nomeEspecialidade, Pageable pageable) {
         Page<Solicitacao> pageSolicitacoes;
@@ -75,6 +80,39 @@ public class SolicitacaoServiceImpl implements SolicitacaoService {
         }
         if (pageSolicitacoes.isEmpty()) {
             throw new EntityNotFoundException("Não foram encontradas solicitações para o paciente informado");
+        }
+        return pageSolicitacoes.map(this.solicitacaoMapper::toDto);
+    }
+
+    @Override
+    public Page<SolicitacaoDTO> listarSolicitacoesMedico(UUID uuidMedico, LocalDate dataParaAtendimento,
+            String nomeEspecialidade, Pageable pageable) {
+        Page<Solicitacao> pageSolicitacoes;
+        if (uuidMedico == null) {
+            throw new BussinesRuleException("O uuid do médico não pode ser nulo");
+        }
+        Medico medico = medicoRepository.findByUuid(uuidMedico);
+        if (medico == null) {
+            throw new EntityNotFoundException("Não foi encontrado um médico com o uuid informado");
+        }
+        List<EspecialidadeMedica> especialidadesMedicas = medico.getEspecialidades();
+        if (especialidadesMedicas.isEmpty()) {
+            throw new EntityNotFoundException("O médico informado não possui especialidades cadastradas");
+        }
+        if (dataParaAtendimento == null && nomeEspecialidade == null) {
+            pageSolicitacoes = solicitacaoRepository.findByEspecialidadeMedicaIn(especialidadesMedicas, pageable);
+        } else if (dataParaAtendimento != null && nomeEspecialidade == null) {
+            pageSolicitacoes = solicitacaoRepository.findByEspecialidadeMedicaInAndDataParaAtendimento(
+                    especialidadesMedicas, dataParaAtendimento, pageable);
+        } else if (dataParaAtendimento == null && nomeEspecialidade != null) {
+            UUID uuidEspecialidade = especialidadeMedicaRepository.findByNomeEspecialidade(nomeEspecialidade).getUuid();
+            pageSolicitacoes = solicitacaoRepository.findByEspecialidadeMedicaUuid(uuidEspecialidade, pageable);
+        } else {
+            UUID uuidEspecialidade = especialidadeMedicaRepository.findByNomeEspecialidade(nomeEspecialidade).getUuid();
+            pageSolicitacoes = solicitacaoRepository.findByEspecialidadeMedicaUuidAndDataParaAtendimento(uuidEspecialidade, dataParaAtendimento, pageable);
+        }
+        if (pageSolicitacoes.isEmpty()) {
+            throw new EntityNotFoundException("Não foram encontradas solicitações para o médico informado");
         }
         return pageSolicitacoes.map(this.solicitacaoMapper::toDto);
     }


### PR DESCRIPTION
Criado o endpoint para listagem de solicitações para o medico, permitindo que um medico possa ver todas as solicitações que correspondem as suas especialidades, podendo filtrar por data de atendimento ou por uma especialidade específica.
Exemplo de requisições para listar as solicitações de um paciente:
![image](https://user-images.githubusercontent.com/88343716/216207041-d2a6114d-efd9-4c99-b800-a6ff000121b5.png)

![image](https://user-images.githubusercontent.com/88343716/216207090-ea6cc9fa-36ac-4641-84b1-da99ad7ee6e3.png)

Exemplo de requisições para listar as solicitações de um médico:
![image](https://user-images.githubusercontent.com/88343716/216207558-95132a37-b857-4f77-98a2-ec06d8e22e3c.png)

![image](https://user-images.githubusercontent.com/88343716/216207602-d525aea5-7da4-4107-9886-45f577d4a315.png)